### PR TITLE
fix: update by denom query

### DIFF
--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -21,7 +21,7 @@ export const DEFAULT: RequestRegistry = {
     adapter,
   },
   bank_supply: { url: '/cosmos/bank/v1beta1/supply', adapter },
-  bank_supply_by_denom: { url: '/cosmos/bank/v1beta1/supply/{denom}', adapter },
+  bank_supply_by_denom: { url: '/cosmos/bank/v1beta1/supply/by_denom?denom={denom}', adapter },
   distribution_params: { url: '/cosmos/distribution/v1beta1/params', adapter },
   distribution_community_pool: {
     url: '/cosmos/distribution/v1beta1/community_pool',


### PR DESCRIPTION
Currently the explorer produces this error on some pages:
```
https://$RPC/cosmos/bank/v1beta1/supply/upoa net::ERR_FAILED 501 (Not Implemented)
```

This fixes it by updating the interface